### PR TITLE
fix: Correct MQL5 syntax for array parameters in SMC module

### DIFF
--- a/SMC.mqh
+++ b/SMC.mqh
@@ -115,7 +115,7 @@ struct FVGInfo
 //| Identify Fair Value Gaps (FVGs)                                  |
 //+------------------------------------------------------------------+
 // Returns the number of FVGs found and populates the fvgs_array
-int IdentifyFVG(string symbol, ENUM_TIMEFRAMES timeframe, int lookback_bars, double min_fvg_size_points, out FVGInfo &fvgs_array[])
+int IdentifyFVG(string symbol, ENUM_TIMEFRAMES timeframe, int lookback_bars, double min_fvg_size_points, FVGInfo &fvgs_array[])
   {
    ArrayFree(fvgs_array); // Clear the array before populating
 
@@ -226,7 +226,7 @@ int IdentifyOrderBlocks(string symbol, ENUM_TIMEFRAMES timeframe,
                           double min_ob_body_percent, // Min body size relative to candle range (0-100)
                           int bos_validation_lookforward, // How many bars after OB to check for BOS
                           double bos_min_move_points, // Min points for the move after OB to be considered significant for BOS
-                          out OrderBlockInfo &obs_array[])
+                          OrderBlockInfo &obs_array[])
   {
    ArrayFree(obs_array);
    MqlRates rates[];


### PR DESCRIPTION
I corrected function signatures in `SMC.mqh` for `IdentifyFVG` and `IdentifyOrderBlocks` by removing the non-standard `out` keyword. MQL5 passes arrays by reference by default when they are not declared `const`.

This change addresses compilation errors you reported, including:
- 'out' - declaration without type
- 'comma expected'
- 'variable expected'
- 'array required'
- 'illegal operation use'
- 'parameter conversion not allowed' (when calling from TradeLogic.mqh)

Typos like 'fugs_array' and 'obs_ array' were also reviewed and ensured to be correct ('fvgs_array', 'obs_array').